### PR TITLE
Domain names in function

### DIFF
--- a/alterator/domain-controller.diag
+++ b/alterator/domain-controller.diag
@@ -32,6 +32,12 @@ display_name.ru = "Проверка: содержит ли файлы катал
 comment.en = "Checking if the sysvol directory is empty"
 comment.ru = "Проверка: содержит ли файлы каталог sysvol"
 
+[tests.does_sysvol_contain_necessary_files]
+display_name.en = "Checking the location in sysvol of the folder with the domain name and Policies and scripts inside"
+display_name.ru = "Проверка нахождения в sysvol папки с именем домена и Policies и scripts внутри"
+comment.en = "Checking the location in sysvol of the folder with the domain name and Policies and scripts inside"
+comment.ru = "Проверка нахождения в sysvol папки с именем домена и Policies и scripts внутри"
+
 [tests.is_samba_package_installed]
 display_name.en = "Checking for the samba package in the system"
 display_name.ru = "Проверка наличия установленного в системе пакета samba"

--- a/diag-domain-controller
+++ b/diag-domain-controller
@@ -590,14 +590,10 @@ does_resolv_conf_and_default_realm_it_match() {
 does_smb_realm_and_krb5_default_realm_it_match() {
     local retval=0
     local smb_realm=
-    local krb5_default_realm_line=
     local krb5_default_realm=
-    local domains=
-    local realm=
 
     if which testparm >/dev/null 2>&1; then
-        smb_realm="$(testparm -l -v -s 2>/dev/null | grep "^\s*realm\s*=" | sed -e 's/^\s*realm\s*=\s*//' -e 's/\s*$//')"
-        smb_realm="$(echo "$smb_realm" | tr '[:upper:]' '[:lower:]')"
+        smb_realm="$(__get_smb_realm)"
 
         echo "The compliance of the realm record in smb.conf is checked using the testparm utility."
 
@@ -615,9 +611,7 @@ does_smb_realm_and_krb5_default_realm_it_match() {
     fi
 
     if test -e /etc/krb5.conf; then
-        krb5_default_realm_line="$(grep "^\s*default_realm\s\+" /etc/krb5.conf || true)"
-        krb5_default_realm="$(echo "$krb5_default_realm_line" | sed -e 's/^\s*default_realm\s*=\s*//' -e 's/\s*$//')"
-        krb5_default_realm="$(echo "$krb5_default_realm" | tr '[:upper:]' '[:lower:]')"
+        krb5_default_realm="$(__get_krb5_default_realm)"
 
         echo "The following realm entry has been defined from the \"krb5.conf\" configuration file:"
         echo -e "$krb5_default_realm\n"
@@ -626,7 +620,9 @@ does_smb_realm_and_krb5_default_realm_it_match() {
         retval=1
     fi
 
-    test "$smb_realm" = "$krb5_default_realm" || retval=2
+    if test "$retval" != 1; then
+        test "$smb_realm" = "$krb5_default_realm" || retval=2
+    fi
 
     if test "$retval" = 0; then
         echo "The realm entry from the \"krb5.conf\" configuration file is the same as the realm entry from the \"smb.conf\" configuration file."

--- a/diag-domain-controller
+++ b/diag-domain-controller
@@ -294,8 +294,7 @@ is_hostname_correct() {
     local retval=0
     local smb_realm=
 
-    smb_realm="$(testparm -l -v -s 2>/dev/null | grep "^\s*realm\s*=" | sed -e 's/^\s*realm\s*=\s*//' -e 's/\s*$//')"
-    smb_realm="$(echo "$smb_realm" | tr '[:upper:]' '[:lower:]')"
+    smb_realm="$(__get_smb_realm)"
     hostname="$(hostname -s)"
     fqdn_hostname="$(hostname -f)"
     validate_regex="^(([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9\-]*[a-zA-Z0-9])\.)*([A-Za-z0-9]|[A-Za-z0-9][A-Za-z0-9\-]*[A-Za-z0-9])$"
@@ -308,8 +307,10 @@ is_hostname_correct() {
         if test "$retval" -eq 1; then
             echo "Wrong hostname. It may contain prohibited characters."
         else
-            grep -E "^[^.]+.$smb_realm$" >/dev/null 2>&1 <<< "$fqdn_hostname" &&
+            grep -E "^[^.]+.$smb_realm$" >/dev/null 2>&1 <<< "$fqdn_hostname" || retval=2
+            if test "$retval" -eq 2; then
                 echo "Controller name is not FQDN or domain_realm does not match. This may cause some problems."
+            fi
         fi
     fi
 

--- a/diag-domain-controller
+++ b/diag-domain-controller
@@ -233,6 +233,44 @@ task() {
     esac
 }
 
+# Getting a lowercase string
+__get_upper_string() {
+    echo "$(tr '[:upper:]' '[:lower:]')"
+}
+
+# Getting a realm record from smb.conf
+__get_smb_realm() {
+    local smb_realm=
+
+    smb_realm="$(testparm -l -v -s 2>/dev/null | grep "^\s*realm\s*=" | sed -e 's/^\s*realm\s*=\s*//' -e 's/\s*$//')"
+    smb_realm="$(echo "$smb_realm" | __get_upper_string)"
+
+    echo $smb_realm
+}
+
+# Getting a realm record from krb5.conf
+__get_krb5_default_realm() {
+    local krb5_default_realm_line=
+    local krb5_default_realm=
+
+    krb5_default_realm_line="$(grep "^\s*default_realm\s\+" /etc/krb5.conf || true)"
+    krb5_default_realm="$(echo "$krb5_default_realm_line" | sed -e 's/^\s*default_realm\s*=\s*//' -e 's/\s*$//')"
+    krb5_default_realm="$(echo "$krb5_default_realm" | __get_upper_string)"
+
+    echo $krb5_default_realm
+}
+
+# Getting a domain name from resolv.conf
+__get_resolv_search_domains() {
+    local search_line=
+    local search_domains=
+
+    search_line="$(grep "^search\s\+" /etc/resolv.conf || true)"
+    search_domains="$(echo "$search_line" | sed -e 's/^search\s\+//' -e 's/\s\+$//')"
+
+    echo $search_domains
+}
+
 # Checking the availability of writing general domain information
 is_domain_info_available() {
     local retval=0

--- a/diag-domain-controller
+++ b/diag-domain-controller
@@ -368,6 +368,50 @@ is_not_empty_sysvol() {
     return "$retval"
 }
 
+# Checking the location in sysvol of the folder with the domain name and "Policies" and "scripts" inside
+does_sysvol_contain_necessary_files() {
+    local retval=0
+    local path_to_sysvol=
+    local smb_realm=
+    local files_list_in_sysvol=
+    local files_list_in_domain_name=
+    local required_files=
+
+    path_to_sysvol="/var/lib/samba/sysvol"
+    required_files="$(echo -e "Policies\nscripts")"
+
+    if test -e /etc/samba/smb.conf; then
+        smb_realm="$(__get_smb_realm)"
+
+        if test -z "$smb_realm"; then
+            echo -e "The realm record was not found in the \"smb.conf\" configuration file.\n"
+            retval=1
+        fi
+    else
+	    echo "The smb.conf file does not exist, no further verification is possible."
+        retval=1
+    fi
+
+    if test "$retval" = 0; then
+        files_list_in_sysvol="$(ls -A "$path_to_sysvol/$smb_realm")"
+
+        for folder in $required_files; do
+            if echo "$files_list_in_sysvol" | grep -q "^$folder$"; then
+                if test -z "$(ls -A "$path_to_sysvol/$smb_realm/$folder")"; then
+                    echo -e "The \"$folder\" folder is empty."
+                    retval=2
+                else
+                    echo -e "The \"$folder\" folder is not empty."
+                fi
+            else
+                echo -e "The \"$folder\" folder is not found."
+            fi
+        done
+    fi
+
+    return $retval
+}
+
 # Checking for the samba package in the system
 is_samba_package_installed() {
     local retval=0
@@ -696,6 +740,7 @@ task is_domain_info_available
 task is_hostname_correct
 task is_hostname_static_and_transient
 task is_not_empty_sysvol
+task does_sysvol_contain_necessary_files
 task is_samba_package_installed
 task is_samba_service_running
 task is_resolve_local

--- a/diag-domain-controller
+++ b/diag-domain-controller
@@ -548,17 +548,11 @@ is_resolv_conf_file_exists() {
 # Checking whether the realm record in the krb5.conf configuration file matches one of the domain names in the resolv.conf configuration file
 does_resolv_conf_and_default_realm_it_match() {
     local retval=2
-    local search_line=
     local search_domains=
-    local krb5_default_realm_line=
     local krb5_default_realm=
-    local domains=
-    local realm=
 
     if test -e /etc/resolv.conf; then
-        search_line="$(grep "^search\s\+" /etc/resolv.conf || true)"
-        search_domains="$(echo "$search_line" | sed -e 's/^search\s\+//' -e 's/\s\+$//')"
-        domains=$(echo "$search_domains=" | tr '[:upper:]' '[:lower:]')
+        search_domains="$(__get_resolv_search_domains)"
 
         echo "The following domain names are defined from the \"resolv.conf\" configuration file:"
         echo -e "$search_domains\n"
@@ -568,9 +562,7 @@ does_resolv_conf_and_default_realm_it_match() {
     fi
 
     if test -e /etc/krb5.conf; then
-        krb5_default_realm_line="$(grep "^\s*default_realm\s\+" /etc/krb5.conf || true)"
-        krb5_default_realm="$(echo "$krb5_default_realm_line" | sed -e 's/^\s*default_realm\s*=\s*//' -e 's/\s*$//')"
-        realm=$(echo "$krb5_default_realm=" | tr '[:upper:]' '[:lower:]')
+        krb5_default_realm="$(__get_krb5_default_realm)"
 
         echo "The following realm entry has been defined from the \"krb5.conf\" configuration file:"
         echo -e "$krb5_default_realm\n"
@@ -579,9 +571,11 @@ does_resolv_conf_and_default_realm_it_match() {
         retval=1
     fi
 
-    for domain in $domains; do
-        test "$domain" = "$realm" && retval=0
-    done
+    if test "$retval" != 1; then
+        for domain in $search_domains; do
+            test "$domain" = "$krb5_default_realm" && retval=0
+        done
+    fi
 
     if test "$retval" = 0; then
         echo "The realm entry from the \"krb5.conf\" file matches the domain name defined in the \"resolv.conf\" file."


### PR DESCRIPTION
The variables in which the domain names from the configuration files "smb.conf", "krb5.conf" and "resolv.conf" are stored are placed in separate functions for further invocation in the corresponding tests.
Added a test to check non-empty "Policies" and "scripts" folders in "/var/lib/samba/sysvol/<domain_name>".